### PR TITLE
permitir unidades = falsy; definiciones typescript

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,7 @@
 interface Opciones {
   unidad?: string | false | null
   mayus?: boolean
+  centavosSiempre?: boolean
 }
 
 declare function numalet (opciones?: Opciones): (n: number) => string;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,8 @@
+interface Opciones {
+  unidad?: string | false | null
+  mayus?: boolean
+}
+
+declare function numalet (opciones?: Opciones): (n: number) => string;
+
+export = numalet

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 module.exports = function(opt){
     opt = {
-        unidad : (opt)?opt.unidad || 'MXN': 'MXN',
+        unidad : opt && typeof opt.unidad !== 'undefined' ? opt.unidad : 'MXN',
         mayus : (opt && (opt.mayus === false))?opt.mayus : true
     };
     return function(n){

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 module.exports = function(opt){
     opt = {
         unidad : opt && typeof opt.unidad !== 'undefined' ? opt.unidad : 'MXN',
-        mayus : (opt && (opt.mayus === false))?opt.mayus : true
+        mayus : (opt && (opt.mayus === false))?opt.mayus : true,
+        centavosSiempre : opt && typeof opt.centavosSiempre !== 'undefined' ? opt.centavosSiempre : false
     };
     return function(n){
 
@@ -129,6 +130,9 @@ module.exports = function(opt){
             if(string.indexOf('.') > -1){
                 decimal = string.split('.')[1];
                 decimal = decimal.charAt(0) + (decimal.charAt(1) || '0');
+            }
+            else if (opt.centavosSiempre) {
+                decimal = '00';
             }
             if (n === 0) {
                 return "cero";

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lib"
   ],
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "keywords": [
     "numero",
     "letra",


### PR DESCRIPTION
Ahora puedes hacer `const num2let = numalet({ unidad: false })` y no te incluiría moneda. El default sigue siendo 'MXN'.

Definiciones typescript.